### PR TITLE
Support a new target allocation strategy: per-zone

### DIFF
--- a/cmd/otel-allocator/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing_test.go
@@ -4,10 +4,13 @@
 package allocation
 
 import (
+	"k8s.io/client-go/rest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var consistentHashingKubeConfig = rest.Config{}
 
 func TestRelativelyEvenDistribution(t *testing.T) {
 	numCols := 15
@@ -15,7 +18,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 	cols := MakeNCollectors(numCols, 0)
 	var expectedPerCollector = float64(numItems / numCols)
 	expectedDelta := (expectedPerCollector * 1.5) - expectedPerCollector
-	c, _ := New("consistent-hashing", logger)
+	c, _ := New("consistent-hashing", &consistentHashingKubeConfig, logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, 0, 0))
 	actualTargetItems := c.TargetItems()
@@ -29,7 +32,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 
 func TestFullReallocation(t *testing.T) {
 	cols := MakeNCollectors(10, 0)
-	c, _ := New("consistent-hashing", logger)
+	c, _ := New("consistent-hashing", &consistentHashingKubeConfig, logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(10000, 10, 0))
 	actualTargetItems := c.TargetItems()
@@ -54,7 +57,7 @@ func TestNumRemapped(t *testing.T) {
 	numFinalCols := 16
 	expectedDelta := float64((numFinalCols - numInitialCols) * (numItems / numFinalCols))
 	cols := MakeNCollectors(numInitialCols, 0)
-	c, _ := New("consistent-hashing", logger)
+	c, _ := New("consistent-hashing", &consistentHashingKubeConfig, logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, numInitialCols, 0))
 	actualTargetItems := c.TargetItems()
@@ -83,7 +86,7 @@ func TestNumRemapped(t *testing.T) {
 
 func TestTargetsWithNoCollectorsConsistentHashing(t *testing.T) {
 
-	c, _ := New("consistent-hashing", logger)
+	c, _ := New("consistent-hashing", &consistentHashingKubeConfig, logger)
 
 	// Adding 10 new targets
 	numItems := 10

--- a/cmd/otel-allocator/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/allocation/least_weighted_test.go
@@ -5,6 +5,7 @@ package allocation
 
 import (
 	"fmt"
+	"k8s.io/client-go/rest"
 	"math"
 	"math/rand"
 	"testing"
@@ -14,9 +15,10 @@ import (
 )
 
 var logger = logf.Log.WithName("unit-tests")
+var leastWeightedKubeConfig = rest.Config{}
 
 func TestNoCollectorReassignment(t *testing.T) {
-	s, _ := New("least-weighted", logger)
+	s, _ := New("least-weighted", &leastWeightedKubeConfig, logger)
 
 	cols := MakeNCollectors(3, 0)
 	s.SetCollectors(cols)
@@ -48,7 +50,7 @@ func TestNoCollectorReassignment(t *testing.T) {
 
 // Tests that the newly added collector instance does not get assigned any target when the targets remain the same.
 func TestNoAssignmentToNewCollector(t *testing.T) {
-	s, _ := New("least-weighted", logger)
+	s, _ := New("least-weighted", &leastWeightedKubeConfig, logger)
 
 	// instantiate only 1 collector
 	cols := MakeNCollectors(1, 0)
@@ -100,7 +102,7 @@ func TestNoAssignmentToNewCollector(t *testing.T) {
 func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 
 	// prepare allocator with 3 collectors and 'random' amount of targets
-	s, _ := New("least-weighted", logger)
+	s, _ := New("least-weighted", &leastWeightedKubeConfig, logger)
 
 	cols := MakeNCollectors(3, 0)
 	s.SetCollectors(cols)
@@ -161,7 +163,7 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 }
 
 func TestTargetsWithNoCollectorsLeastWeighted(t *testing.T) {
-	s, _ := New("least-weighted", logger)
+	s, _ := New("least-weighted", &leastWeightedKubeConfig, logger)
 
 	// Adding 10 new targets
 	numItems := 10

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -4,6 +4,7 @@
 package allocation
 
 import (
+	"k8s.io/client-go/rest"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -14,6 +15,7 @@ import (
 )
 
 var loggerPerNode = logf.Log.WithName("unit-tests")
+var perNodeKubeConfig = rest.Config{}
 
 func GetTargetsWithNodeName(targets []*target.Item) (targetsWithNodeName []*target.Item) {
 	for _, item := range targets {
@@ -28,7 +30,7 @@ func GetTargetsWithNodeName(targets []*target.Item) (targetsWithNodeName []*targ
 // target that lacks node labels.
 func TestAllocationPerNode(t *testing.T) {
 	// prepare allocator with initial targets and collectors
-	s, _ := New("per-node", loggerPerNode)
+	s, _ := New("per-node", &perNodeKubeConfig, loggerPerNode)
 
 	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
@@ -95,7 +97,7 @@ func TestAllocationPerNode(t *testing.T) {
 // Tests that four targets, with one of them missing node labels, are all assigned.
 func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	// prepare allocator with initial targets and collectors
-	s, _ := New("per-node", loggerPerNode, WithFallbackStrategy(consistentHashingStrategyName))
+	s, _ := New("per-node", &perNodeKubeConfig, loggerPerNode, WithFallbackStrategy(consistentHashingStrategyName))
 
 	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
@@ -165,7 +167,7 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 
 func TestTargetsWithNoCollectorsPerNode(t *testing.T) {
 	// prepare allocator with initial targets and collectors
-	c, _ := New("per-node", loggerPerNode)
+	c, _ := New("per-node", &perNodeKubeConfig, loggerPerNode)
 
 	// Adding 10 new targets
 	numItems := 10

--- a/cmd/otel-allocator/allocation/per_zone.go
+++ b/cmd/otel-allocator/allocation/per_zone.go
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"context"
+	"fmt"
+	"github.com/buraksezer/consistent"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"time"
+)
+
+const perZoneStrategyName = "per-zone"
+const cacheTTL = 120 * time.Minute
+
+type ZonedNode struct {
+	NodeName string
+	Zone     string
+}
+
+type CollectorZonedNode struct {
+	ZonedNode
+	collector string
+}
+
+type TargetZonedNode struct {
+	ZonedNode
+	target string
+}
+
+func collectorZonedNodeKeyFunc(collectorZonedNode interface{}) (string, error) {
+	return collectorZonedNode.(CollectorZonedNode).collector, nil
+}
+
+func targetZonedNodeKeyFunc(targetZonedNode interface{}) (string, error) {
+	return targetZonedNode.(TargetZonedNode).target, nil
+}
+
+var _ Strategy = &perZoneStrategy{}
+
+type perZoneStrategy struct {
+	k8sClient              kubernetes.Interface
+	config                 consistent.Config
+	collectorToZonedNode   cache.Store
+	targetToZonedNode      cache.Store
+	consistentHasherByZone map[string]*consistent.Consistent
+}
+
+func newPerZoneStrategy(k8sClient kubernetes.Interface) Strategy {
+	config := consistent.Config{
+		PartitionCount:    1061,
+		ReplicationFactor: 5,
+		Load:              1.1,
+		Hasher:            hasher{},
+	}
+	perZoneStrategy := &perZoneStrategy{
+		k8sClient:              k8sClient,
+		config:                 config,
+		consistentHasherByZone: make(map[string]*consistent.Consistent),
+		collectorToZonedNode:   cache.NewTTLStore(collectorZonedNodeKeyFunc, cacheTTL),
+		targetToZonedNode:      cache.NewTTLStore(targetZonedNodeKeyFunc, cacheTTL),
+	}
+	return perZoneStrategy
+}
+
+func (s *perZoneStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	targetUrl := item.TargetURL
+	targetNodeName := item.GetNodeName()
+	targetZonedNode, exist, err := s.targetToZonedNode.GetByKey(targetUrl)
+	if err != nil {
+		fmt.Printf("failed to retrieve target zoned node from cache: %s", err)
+	}
+	if !exist || targetZonedNode.(TargetZonedNode).ZonedNode.NodeName != item.GetNodeName() {
+		k8sNode, err := s.retrieveK8sNode(ctx, targetNodeName)
+		if err != nil {
+			fmt.Printf("err retrieving k8s node %s for target %s: %s\n", item.GetNodeName(), targetUrl, err)
+		}
+		targetNodeZone, exist := k8sNode.ObjectMeta.Labels[v1.LabelTopologyZone]
+		if !exist {
+			fmt.Printf("succeeded to find the target node %s in the cluster but it doesn't support zone awareness", targetNodeName)
+		}
+		targetZonedNode = TargetZonedNode{
+			ZonedNode: ZonedNode{
+				NodeName: targetNodeName,
+				Zone:     targetNodeZone,
+			},
+			target: targetUrl,
+		}
+		err = s.targetToZonedNode.Add(targetZonedNode)
+		if err != nil {
+			fmt.Printf("error adding a cache for the node and zone information that relates to target %s: %s", targetUrl, err)
+		}
+	}
+
+	zonedConsistentHasher, exist := s.consistentHasherByZone[targetZonedNode.(TargetZonedNode).ZonedNode.Zone]
+	if !exist {
+		return nil, fmt.Errorf("unknown Zone %s", targetZonedNode.(TargetZonedNode).ZonedNode.Zone)
+	}
+	member := zonedConsistentHasher.LocateKey([]byte(targetUrl))
+	collectorName := member.String()
+	collector, exist := collectors[collectorName]
+	if !exist {
+		return nil, fmt.Errorf("unknown collector %s", collectorName)
+	}
+	return collector, nil
+}
+
+func (s *perZoneStrategy) SetCollectors(collectors map[string]*Collector) {
+	clear(s.consistentHasherByZone)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	collectorsByZone := make(map[string][]string)
+	defer clear(collectorsByZone)
+
+	for _, collector := range collectors {
+		collectorNodeName := collector.NodeName
+		collectorName := collector.Name
+		collectorZonedNode, exist, err := s.collectorToZonedNode.GetByKey(collectorName)
+		if err != nil {
+			fmt.Printf("failed to retrieve collector zoned node from cache: %s", err)
+		}
+		if !exist || collectorZonedNode.(CollectorZonedNode).ZonedNode.NodeName != collector.NodeName {
+			k8sNode, err := s.retrieveK8sNode(ctx, collectorNodeName)
+			if err != nil {
+				fmt.Printf("error retrieving k8s node %s for collector %s: %s\n", collectorNodeName, collectorName, err)
+				continue
+			}
+			collectorNodeZone, exist := k8sNode.ObjectMeta.Labels[v1.LabelTopologyZone]
+			if !exist {
+				fmt.Printf("succeeded to find the collector node %s for collector %s in the cluster but it doesn't support zone awareness\n", collectorNodeName, collectorName)
+				continue
+			}
+			collectorZonedNode = CollectorZonedNode{
+				ZonedNode: ZonedNode{
+					NodeName: collectorNodeName,
+					Zone:     collectorNodeZone,
+				},
+				collector: collectorName,
+			}
+			err = s.collectorToZonedNode.Add(collectorZonedNode)
+			if err != nil {
+				fmt.Printf("error adding a cache for the node and zone information that relates to collector %s: %s \n", collectorName, err)
+			}
+		}
+		collectorsByZone[collectorZonedNode.(CollectorZonedNode).ZonedNode.Zone] = append(collectorsByZone[collectorZonedNode.(CollectorZonedNode).ZonedNode.Zone], collectorName)
+	}
+
+	var members []consistent.Member
+	for zone, collectorNames := range collectorsByZone {
+		members = make([]consistent.Member, 0, len(collectors))
+		for _, collectorName := range collectorNames {
+			members = append(members, collectors[collectorName])
+		}
+		s.consistentHasherByZone[zone] = consistent.New(members, s.config)
+	}
+}
+
+func (s *perZoneStrategy) GetName() string {
+	return perZoneStrategyName
+}
+
+func (s *perZoneStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}
+
+func (s *perZoneStrategy) retrieveK8sNode(ctx context.Context, nodeName string) (*v1.Node, error) {
+	var node *v1.Node
+	var err error
+	if node, err = s.k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("could not find the node %s in the cluster\n", nodeName)
+		}
+		return nil, fmt.Errorf("error when finding the node %s in the cluster, see error %s\n", nodeName, err)
+	}
+	return node, nil
+}

--- a/cmd/otel-allocator/allocation/per_zone_test.go
+++ b/cmd/otel-allocator/allocation/per_zone_test.go
@@ -1,0 +1,209 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"fmt"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var loggerPerZone = logf.Log.WithName("unit-tests")
+
+func TestAllocationPerZone(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-2",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-3",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		})
+
+	perZoneStrategy := newPerZoneStrategy(k8sClient)
+	perZoneAllocator := newAllocator(loggerPerZone, perZoneStrategy)
+
+	cols := MakeNCollectors(3, 0)
+	perZoneAllocator.SetCollectors(cols)
+
+	firstTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	}
+	secondTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-1"},
+	}
+	thirdTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-2"},
+	}
+	forthTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-3"},
+	}
+
+	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstTargetLabels, "")
+	secondTarget := target.NewItem("sample-name", "0.0.0.1:8000", secondTargetLabels, "")
+	thirdTarget := target.NewItem("sample-name", "0.0.0.2:8000", thirdTargetLabels, "")
+	fourthTarget := target.NewItem("sample-name", "0.0.0.3:8000", forthTargetLabels, "")
+
+	targetList := map[string]*target.Item{
+		firstTarget.Hash():  firstTarget,
+		secondTarget.Hash(): secondTarget,
+		thirdTarget.Hash():  thirdTarget,
+		fourthTarget.Hash(): fourthTarget,
+	}
+
+	perZoneAllocator.SetTargets(targetList)
+
+	actualItems := perZoneAllocator.TargetItems()
+	expectedTargetLen := len(targetList)
+	assert.Len(t, actualItems, expectedTargetLen)
+
+	// verify allocation to nodes
+	for targetHash, item := range targetList {
+		actualItem, found := actualItems[targetHash]
+		assert.True(t, found, "target with hash %s not found", item.Hash())
+
+		itemsForCollector := perZoneAllocator.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
+
+		if targetHash == firstTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-0")
+			continue
+		}
+		if targetHash == secondTarget.Hash() {
+			assert.Len(t, itemsForCollector, 2)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+		if targetHash == thirdTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-2")
+			continue
+		}
+		if targetHash == fourthTarget.Hash() {
+			assert.Len(t, itemsForCollector, 2)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+	}
+}
+
+// Test with no collector in a specific zone
+func TestTargetsWithZoneDoesNotHaveCollectors(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-2",
+				},
+			},
+		})
+
+	perZoneStrategy := newPerZoneStrategy(k8sClient)
+	perZoneAllocator := newAllocator(loggerPerZone, perZoneStrategy)
+
+	cols := MakeNCollectors(2, 0)
+	perZoneAllocator.SetCollectors(cols)
+
+	firstTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	}
+	secondTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-1"},
+	}
+	thirdTargetLabels := labels.Labels{ // won't have a collector in the zone-2
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-2"},
+	}
+
+	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstTargetLabels, "")
+	secondTarget := target.NewItem("sample-name", "0.0.0.1:8000", secondTargetLabels, "")
+	thirdTarget := target.NewItem("sample-name", "0.0.0.2:8000", thirdTargetLabels, "")
+
+	targetList := map[string]*target.Item{
+		firstTarget.Hash():  firstTarget,
+		secondTarget.Hash(): secondTarget,
+		thirdTarget.Hash():  thirdTarget,
+	}
+
+	perZoneAllocator.SetTargets(targetList)
+
+	mapString := fmt.Sprintf("%v", perZoneAllocator.TargetItems())
+	fmt.Println(mapString)
+
+	actualItems := perZoneAllocator.TargetItems()
+	expectedTargetLen := len(targetList)
+	assert.Len(t, actualItems, expectedTargetLen)
+
+	// verify allocation to nodes
+	for targetHash, item := range targetList {
+		actualItem, found := actualItems[targetHash]
+		assert.True(t, found, "target with hash %s not found", item.Hash())
+
+		itemsForCollector := perZoneAllocator.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
+
+		if targetHash == firstTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+		if targetHash == secondTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+		if targetHash == thirdTarget.Hash() {
+			assert.Len(t, itemsForCollector, 0)
+			assert.Equal(t, actualItem.CollectorName, "")
+			continue
+		}
+	}
+}

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -5,6 +5,8 @@ package allocation
 
 import (
 	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/buraksezer/consistent"
 	"github.com/go-logr/logr"
@@ -73,8 +75,16 @@ func RecordTargetsKept(targets map[string]*target.Item) {
 	TargetsRemaining.Set(float64(len(targets)))
 }
 
-func New(name string, log logr.Logger, opts ...Option) (Allocator, error) {
+func New(name string, kubeConfig *rest.Config, log logr.Logger, opts ...Option) (Allocator, error) {
 	if strategy, ok := strategies[name]; ok {
+		return newAllocator(log.WithValues("allocator", name), strategy, opts...), nil
+	}
+	if name == perZoneStrategyName {
+		k8sClient, err := kubernetes.NewForConfig(kubeConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a new k8s client: %s", err)
+		}
+		strategy := newPerZoneStrategy(k8sClient)
 		return newAllocator(log.WithValues("allocator", name), strategy, opts...), nil
 	}
 	return nil, fmt.Errorf("unregistered strategy: %s", name)

--- a/cmd/otel-allocator/allocation/strategy_test.go
+++ b/cmd/otel-allocator/allocation/strategy_test.go
@@ -5,11 +5,14 @@ package allocation
 
 import (
 	"fmt"
+	"k8s.io/client-go/rest"
 	"reflect"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
 )
+
+var stategyTestKubeConfig = rest.Config{}
 
 func BenchmarkGetAllTargetsByCollectorAndJob(b *testing.B) {
 	var table = []struct {
@@ -27,7 +30,7 @@ func BenchmarkGetAllTargetsByCollectorAndJob(b *testing.B) {
 	}
 	for _, s := range GetRegisteredAllocatorNames() {
 		for _, v := range table {
-			a, err := New(s, logger)
+			a, err := New(s, &stategyTestKubeConfig, logger)
 			if err != nil {
 				b.Log(err)
 				b.Fail()
@@ -63,7 +66,7 @@ func Benchmark_Setting(b *testing.B) {
 
 	for _, s := range GetRegisteredAllocatorNames() {
 		for _, v := range table {
-			a, _ := New(s, logger)
+			a, _ := New(s, &stategyTestKubeConfig, logger)
 			cols := MakeNCollectors(v.numCollectors, 0)
 			targets := MakeNNewTargets(v.numTargets, v.numCollectors, 0)
 			b.Run(fmt.Sprintf("%s_num_cols_%d_num_jobs_%d", s, v.numCollectors, v.numTargets), func(b *testing.B) {

--- a/cmd/otel-allocator/allocation/testutils.go
+++ b/cmd/otel-allocator/allocation/testutils.go
@@ -7,6 +7,7 @@ package allocation
 
 import (
 	"fmt"
+	"k8s.io/client-go/rest"
 	"strconv"
 	"testing"
 
@@ -68,9 +69,10 @@ func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*ta
 func RunForAllStrategies(t *testing.T, f func(t *testing.T, allocator Allocator)) {
 	allocatorNames := GetRegisteredAllocatorNames()
 	logger := logf.Log.WithName("unit-tests")
+	kubeConfig := rest.Config{}
 	for _, allocatorName := range allocatorNames {
 		t.Run(allocatorName, func(t *testing.T) {
-			allocator, err := New(allocatorName, logger)
+			allocator, err := New(allocatorName, &kubeConfig, logger)
 			require.NoError(t, err)
 			f(t, allocator)
 		})

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -70,7 +70,7 @@ func main() {
 	log := ctrl.Log.WithName("allocator")
 
 	allocatorPrehook = prehook.New(cfg.FilterStrategy, log)
-	allocator, err = allocation.New(cfg.AllocationStrategy, log, allocation.WithFilter(allocatorPrehook), allocation.WithFallbackStrategy(cfg.AllocationFallbackStrategy))
+	allocator, err = allocation.New(cfg.AllocationStrategy, cfg.ClusterConfig, log, allocation.WithFilter(allocatorPrehook), allocation.WithFallbackStrategy(cfg.AllocationFallbackStrategy))
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize allocation strategy")
 		os.Exit(1)


### PR DESCRIPTION
**Description:**
This PR is to support a new target allocation strategy : per-zone.

TLDR of this new strategy: all targets from a specific zone will only be scraped by collectors from the same zone.

**Link to tracking Issue(s):** <Issue number if applicable>
TBD

**Testing:** <Describe what testing was performed and which tests were added.>
TBD

**Documentation:** <Describe the documentation added.>
TBD